### PR TITLE
Implement telegram command for saved users

### DIFF
--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from datetime import date
 from django.conf import settings
 from django.template.loader import get_template
@@ -75,6 +76,54 @@ async def schedule(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(error_message)
 
 
+async def users(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Shows a list of saved users with pagination support."""
+    # Register the user first
+    await register_user(update, context)
+    
+    try:
+        # Get page number from command arguments (default to 1)
+        page = 1
+        if context.args and context.args[0].isdigit():
+            page = int(context.args[0])
+        
+        # Ensure page is at least 1
+        page = max(1, page)
+        
+        # Get users list and stats
+        users_list, total_users = await sync_to_async(TelegramUserService.get_users_list)(page, 20)
+        stats = await sync_to_async(TelegramUserService.get_user_stats)()
+        
+        if not users_list and page == 1:
+            # No users found and it's the first page
+            template = get_template('telegram_bot/users_empty.txt')
+            message = template.render()
+        else:
+            # Calculate pagination info
+            page_size = 20
+            total_pages = math.ceil(total_users / page_size) if total_users > 0 else 1
+            next_page = page + 1 if page < total_pages else None
+            
+            # Use users template with context
+            template = get_template('telegram_bot/users.txt')
+            message = template.render({
+                'users': users_list,
+                'total_users': stats['total_users'],
+                'active_users': stats['active_users_30d'],
+                'premium_users': stats['premium_users'],
+                'verified_users': stats['verified_users'],
+                'current_page': page,
+                'total_pages': total_pages,
+                'next_page': next_page,
+            })
+        
+        await update.message.reply_text(message, parse_mode="Markdown")
+        
+    except Exception as e:
+        logger.error(f"Error in users command: {str(e)}")
+        await update.message.reply_text("❌ Error retrieving users list. Please try again later.")
+
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle all incoming messages and register users."""
     # Register the user for any message interaction
@@ -93,6 +142,7 @@ def main() -> None:
     # on different commands - answer in Telegram
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("schedule", schedule))
+    application.add_handler(CommandHandler("users", users))
     
     # Handle all other messages (this will register users for any interaction)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))

--- a/telegram_bot/services.py
+++ b/telegram_bot/services.py
@@ -2,7 +2,7 @@
 Services for handling Telegram user operations.
 """
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 from django.db import transaction
 from django.utils import timezone
 from telegram import User as TelegramUser
@@ -161,3 +161,25 @@ class TelegramUserService:
                 'premium_users': 0,
                 'verified_users': 0,
             }
+    
+    @staticmethod
+    def get_users_list(page: int = 1, page_size: int = 20) -> Tuple[List[TelegramUserModel], int]:
+        """
+        Get a paginated list of users.
+        
+        Args:
+            page: Page number (1-based)
+            page_size: Number of users per page
+            
+        Returns:
+            Tuple of (list of users, total count)
+        """
+        try:
+            offset = (page - 1) * page_size
+            users = list(TelegramUserModel.objects.all().order_by('-created_at')[offset:offset + page_size])
+            total_count = TelegramUserModel.objects.count()
+            
+            return users, total_count
+        except Exception as e:
+            logger.error(f"Error getting users list: {str(e)}")
+            return [], 0

--- a/telegram_bot/templates/telegram_bot/users.txt
+++ b/telegram_bot/templates/telegram_bot/users.txt
@@ -1,0 +1,22 @@
+👥 **Saved Users List**
+
+📊 **Statistics:**
+• Total Users: {{ total_users }}
+• Active (30d): {{ active_users }}
+• Premium: {{ premium_users }}
+• Verified: {{ verified_users }}
+
+📋 **Users (Page {{ current_page }}/{{ total_pages }}):**
+{% for user in users %}
+{{ forloop.counter }}. **{{ user.full_name }}**
+   ID: `{{ user.telegram_id }}`
+   Username: @{{ user.username|default:"N/A" }}
+   Language: {{ user.language_code|default:"N/A" }}
+   Status: {% if user.is_premium %}⭐ Premium{% endif %}{% if user.is_verified %} ✓ Verified{% endif %}{% if user.is_bot %} 🤖 Bot{% endif %}{% if not user.is_premium and not user.is_verified and not user.is_bot %}👤 Regular{% endif %}
+   Last Seen: {{ user.last_seen|date:"M d, Y H:i" }}
+   Joined: {{ user.created_at|date:"M d, Y" }}
+
+{% endfor %}
+{% if total_pages > 1 %}
+📄 Use `/users {{ next_page }}` for next page
+{% endif %}

--- a/telegram_bot/templates/telegram_bot/users_empty.txt
+++ b/telegram_bot/templates/telegram_bot/users_empty.txt
@@ -1,0 +1,7 @@
+👥 **Saved Users List**
+
+📊 **No users found in the database.**
+
+The bot hasn't registered any users yet. Users will be automatically added when they interact with the bot using any command or send a message.
+
+Try using `/start` or `/schedule` commands to register users first.


### PR DESCRIPTION
Add `/users` Telegram command to display a paginated list of saved users, improving bot administration and user visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6e6a70f-e48b-4284-b0b4-d113e38e3874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6e6a70f-e48b-4284-b0b4-d113e38e3874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

